### PR TITLE
chore(renovate): disable `custom.firefox` while waiting for upstream fix

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,12 +9,12 @@
   ],
   "dependencyDashboardTitle": "Renovate Dashboard",
   "customDatasources": {
-//      "firefox": {
-//        "defaultRegistryUrlTemplate": "https://product-details.mozilla.org/1.0/firefox_versions.json",
-//        "transformTemplates": [
-//          "{\"releases\": [{ \"version\": $.{{packageName}} }] }"
-//        ],
-//      },
+      "firefox": {
+        "defaultRegistryUrlTemplate": "https://product-details.mozilla.org/1.0/firefox_versions.json",
+        "transformTemplates": [
+          "{\"releases\": [{ \"version\": $.{{packageName}} }] }",
+        ],
+      },
       "putty": {
         "defaultRegistryUrlTemplate": "https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html",
         "format": "html",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,12 +9,12 @@
   ],
   "dependencyDashboardTitle": "Renovate Dashboard",
   "customDatasources": {
-      "firefox": {
-        "defaultRegistryUrlTemplate": "https://product-details.mozilla.org/1.0/firefox_versions.json",
-        "transformTemplates": [
-          "{\"releases\": [{ \"version\": $.{{packageName}} }] }"
-        ],
-      },
+//      "firefox": {
+//        "defaultRegistryUrlTemplate": "https://product-details.mozilla.org/1.0/firefox_versions.json",
+//        "transformTemplates": [
+//          "{\"releases\": [{ \"version\": $.{{packageName}} }] }"
+//        ],
+//      },
       "putty": {
         "defaultRegistryUrlTemplate": "https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html",
         "format": "html",

--- a/.github/workflows/full_run_win.yml
+++ b/.github/workflows/full_run_win.yml
@@ -23,7 +23,7 @@ jobs:
     needs: gsv
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - name: Setup Salt
         uses: dafyddj/setup-salt-win@1fe09b1c0cdb721a43f9e5faa9bd079af8701803 # v2.2.0
         with:

--- a/.github/workflows/full_run_win.yml
+++ b/.github/workflows/full_run_win.yml
@@ -23,7 +23,7 @@ jobs:
     needs: gsv
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Setup Salt
         uses: dafyddj/setup-salt-win@1fe09b1c0cdb721a43f9e5faa9bd079af8701803 # v2.2.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       # renovate: datasource=github-releases depName=actions/python-versions extractVersion=^(?<version>\S+)-\d+$
       PYTHON_VERSION: 3.12.7
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -53,7 +53,7 @@ jobs:
           - ${{ fromJSON(needs.gsv.outputs.salt-versions-els) }}
           - ${{ fromJSON(needs.gsv.outputs.salt-versions) }}
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           path: win/repo-ng
       - name: Setup Salt
@@ -80,7 +80,7 @@ jobs:
       - gsv
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - id: changed-files
         name: Get changed files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # renovate: datasource=github-releases depName=actions/python-versions extractVersion=^(?<version>\S+)-\d+$
-      PYTHON_VERSION: 3.12.6
+      PYTHON_VERSION: 3.12.7
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       # renovate: datasource=github-releases depName=actions/python-versions extractVersion=^(?<version>\S+)-\d+$
       PYTHON_VERSION: 3.12.6
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -53,7 +53,7 @@ jobs:
           - ${{ fromJSON(needs.gsv.outputs.salt-versions-els) }}
           - ${{ fromJSON(needs.gsv.outputs.salt-versions) }}
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           path: win/repo-ng
       - name: Setup Salt
@@ -80,7 +80,7 @@ jobs:
       - gsv
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       - id: changed-files
         name: Get changed files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # renovate: datasource=github-releases depName=actions/python-versions extractVersion=^(?<version>\S+)-\d+$
-      PYTHON_VERSION: 3.12.7
+      PYTHON_VERSION: 3.13.0
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--assume-in-merge]
       - id: check-yaml
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.29.2
+    rev: 0.29.3
     hooks:
       - id: check-github-workflows
         name: Check GitHub workflows with check-jsonschema

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 default_stages: [commit]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict

--- a/firefox-esr.sls
+++ b/firefox-esr.sls
@@ -13,6 +13,7 @@
 
 {% load_yaml as versions -%}
 # renovate: datasource=custom.firefox depName=firefox-esr packageName=FIREFOX_ESR
+- '128.3.0'
 - '115.15.0'
 - '115.14.0'
 - '115.13.0'

--- a/firefox.sls
+++ b/firefox.sls
@@ -13,6 +13,7 @@
 
 {% load_yaml as versions -%}
 # renovate: datasource=custom.firefox depName=firefox packageName=LATEST_FIREFOX_VERSION
+- '131.0'
 - '130.0.1'
 - '130.0'
 - '129.0.2'

--- a/git.sls
+++ b/git.sls
@@ -13,6 +13,7 @@
 
 {% load_yaml as versions -%}
 # renovate: datasource=github-releases depName=git packageName=git-for-windows/git
+- '2.47.0.windows.1'
 - '2.46.2.windows.1'
 - '2.46.1.windows.1'
 - '2.46.0.windows.1'

--- a/git.sls
+++ b/git.sls
@@ -13,6 +13,7 @@
 
 {% load_yaml as versions -%}
 # renovate: datasource=github-releases depName=git packageName=git-for-windows/git
+- '2.46.2.windows.1'
 - '2.46.1.windows.1'
 - '2.46.0.windows.1'
 - 2.45.2.windows.1

--- a/git.sls
+++ b/git.sls
@@ -13,7 +13,8 @@
 
 {% load_yaml as versions -%}
 # renovate: datasource=github-releases depName=git packageName=git-for-windows/git
-- 2.46.0.windows.1
+- '2.46.1.windows.1'
+- '2.46.0.windows.1'
 - 2.45.2.windows.1
 - 2.45.1.windows.1
 - 2.45.0.windows.1

--- a/git.sls
+++ b/git.sls
@@ -6,175 +6,172 @@
 
 # There was a short-lived change in version format
 # See https://github.com/git-for-windows/git/issues/2223
-{% set new_style_versions = [
-  '2.23.0',
-  '2.22.0'
-] %}
+{% load_yaml as new_style_versions -%}
+- 2.23.0.windows.1
+- 2.22.0.windows.1
+{% endload -%}
 
 {% load_yaml as versions -%}
-- 2.45.0
-- 2.44.0
-- 2.43.0
-- 2.42.0.2
-- 2.42.0
-- 2.41.0.3
-- 2.41.0
-- 2.40.1
-- 2.40.0
-- 2.39.2
-- 2.39.1
-- 2.39.0.2
-- 2.39.0
-- 2.38.1
-- 2.38.0
-- 2.37.3
-- 2.37.2.2
-- 2.37.1
-- 2.37.0
-- 2.36.1
-- 2.36.0
-- 2.35.3
-- 2.35.2
-- 2.35.1.2
-- 2.35.1
-- 2.35.0
-- 2.34.1
-- 2.34.0
-- 2.33.1
-- 2.33.0.2
-- 2.33.0
-- 2.32.0.2
-- 2.32.0
-- 2.31.1
-- 2.31.0
-- 2.30.2
-- 2.30.1
-- 2.30.0.2
-- 2.30.0
-- 2.29.2.3
-- 2.29.2.2
-- 2.29.2
-- 2.29.1
-- 2.29.0
-- 2.28.0
-- 2.27.0
-- 2.26.2
-- 2.26.1
-- 2.26.0
-- 2.25.1
-- 2.25.0
-- 2.24.1.2
-- 2.24.0.2
-- 2.24.0
-- 2.23.0
-- 2.22.0
-- 2.21.0
-- 2.20.1
-- 2.20.0
-- 2.19.1
-- 2.19.0
-- 2.18.0
-- 2.17.1.2
-- 2.17.1
-- 2.17.0
-- 2.16.3
-- 2.16.2
-- 2.16.1.4
-- 2.16.1.3
-- 2.16.1.2
-- 2.16.1
-- 2.16.0.2
-- 2.15.1.2
-- 2.15.1
-- 2.15.0
-- 2.14.3
-- 2.14.2.3
-- 2.14.2.2
-- 2.14.2
-- 2.14.1
-- 2.14.0.2
-- 2.14.0
-- 2.13.3
-- 2.13.2
-- 2.13.1.2
-- 2.13.1
-- 2.13.0
-- 2.12.2.2
-- 2.12.2
-- 2.12.1
-- 2.12.0
-- 2.11.1
-- 2.11.0.3
-- 2.11.0.2
-- 2.11.0
-- 2.10.2
-- 2.10.1
-- 2.10.0
-- 2.9.3.2
-- 2.9.3
-- 2.9.2
-- 2.9.0
-- 2.8.4
-- 2.8.3
-- 2.8.2
-- 2.8.1
-- 2.8.0
-- 2.7.4
-- 2.7.3
-- 2.7.2
-- 2.7.1.2
-- 2.7.1
-- 2.7.0.2
-- 2.7.0
-- 2.6.4
-- 2.6.3
-- 2.6.2
-- 2.6.1
-- 2.6.0
-- 2.5.3
-- 2.5.2.2
-- 2.5.2
-- 2.5.1
-- 2.5.0
+# renovate: datasource=github-releases depName=git packageName=git-for-windows/git
+- 2.45.0.windows.1
+- 2.44.0.windows.1
+- 2.43.0.windows.1
+- 2.42.0.windows.2
+- 2.42.0.windows.1
+- 2.41.0.windows.3
+- 2.41.0.windows.1
+- 2.40.1.windows.1
+- 2.40.0.windows.1
+- 2.39.2.windows.1
+- 2.39.1.windows.1
+- 2.39.0.windows.2
+- 2.39.0.windows.1
+- 2.38.1.windows.1
+- 2.38.0.windows.1
+- 2.37.3.windows.1
+- 2.37.2.windows.2
+- 2.37.1.windows.1
+- 2.37.0.windows.1
+- 2.36.1.windows.1
+- 2.36.0.windows.1
+- 2.35.3.windows.1
+- 2.35.2.windows.1
+- 2.35.1.windows.2
+- 2.35.1.windows.1
+- 2.35.0.windows.1
+- 2.34.1.windows.1
+- 2.34.0.windows.1
+- 2.33.1.windows.1
+- 2.33.0.windows.2
+- 2.33.0.windows.1
+- 2.32.0.windows.2
+- 2.32.0.windows.1
+- 2.31.1.windows.1
+- 2.31.0.windows.1
+- 2.30.2.windows.1
+- 2.30.1.windows.1
+- 2.30.0.windows.2
+- 2.30.0.windows.1
+- 2.29.2.windows.3
+- 2.29.2.windows.2
+- 2.29.2.windows.1
+- 2.29.1.windows.1
+- 2.29.0.windows.1
+- 2.28.0.windows.1
+- 2.27.0.windows.1
+- 2.26.2.windows.1
+- 2.26.1.windows.1
+- 2.26.0.windows.1
+- 2.25.1.windows.1
+- 2.25.0.windows.1
+- 2.24.1.windows.2
+- 2.24.0.windows.2
+- 2.24.0.windows.1
+- 2.23.0.windows.1
+- 2.22.0.windows.1
+- 2.21.0.windows.1
+- 2.20.1.windows.1
+- 2.20.0.windows.1
+- 2.19.1.windows.1
+- 2.19.0.windows.1
+- 2.18.0.windows.1
+- 2.17.1.windows.2
+- 2.17.1.windows.1
+- 2.17.0.windows.1
+- 2.16.3.windows.1
+- 2.16.2.windows.1
+- 2.16.1.windows.4
+- 2.16.1.windows.3
+- 2.16.1.windows.2
+- 2.16.1.windows.1
+- 2.16.0.windows.2
+- 2.15.1.windows.2
+- 2.15.1.windows.1
+- 2.15.0.windows.1
+- 2.14.3.windows.1
+- 2.14.2.windows.3
+- 2.14.2.windows.2
+- 2.14.2.windows.1
+- 2.14.1.windows.1
+- 2.14.0.windows.2
+- 2.14.0.windows.1
+- 2.13.3.windows.1
+- 2.13.2.windows.1
+- 2.13.1.windows.2
+- 2.13.1.windows.1
+- 2.13.0.windows.1
+- 2.12.2.windows.2
+- 2.12.2.windows.1
+- 2.12.1.windows.1
+- 2.12.0.windows.1
+- 2.11.1.windows.1
+- 2.11.0.windows.3
+- 2.11.0.windows.2
+- 2.11.0.windows.1
+- 2.10.2.windows.1
+- 2.10.1.windows.1
+- 2.10.0.windows.1
+- 2.9.3.windows.2
+- 2.9.3.windows.1
+- 2.9.2.windows.1
+- 2.9.0.windows.1
+- 2.8.4.windows.1
+- 2.8.3.windows.1
+- 2.8.2.windows.1
+- 2.8.1.windows.1
+- 2.8.0.windows.1
+- 2.7.4.windows.1
+- 2.7.3.windows.1
+- 2.7.2.windows.1
+- 2.7.1.windows.2
+- 2.7.1.windows.1
+- 2.7.0.windows.2
+- 2.7.0.windows.1
+- 2.6.4.windows.1
+- 2.6.3.windows.1
+- 2.6.2.windows.1
+- 2.6.1.windows.1
+- 2.6.0.windows.1
+- 2.5.3.windows.1
+- 2.5.2.windows.2
+- 2.5.2.windows.1
+- 2.5.1.windows.1
+- 2.5.0.windows.1
 {% endload -%}
 
 {% load_yaml as uninstall_only -%}
-- 2.19.2
+- 2.19.2.windows.1
 {% endload -%}
 
 git:
-{% for version in versions + uninstall_only %}
-  {% if version.count('.') == 3  %}
-    {% set short_version = version[:-2] %}
-    {% set win_ver = version[-1:] %}
-  {% else %}
-    {% set short_version = version %}
-    {% set win_ver = "1" %}
-  {% endif %}
-  {% set extended_version = short_version ~ ".windows." ~ win_ver %}
-  {% if version in new_style_versions %}
-    {% set display_version = extended_version %}
-  {% else %}
-    {% set display_version = version %}
-  {% endif %}
+{%- for version in versions + uninstall_only %}
+  {% set git_version = version.split(".")[:3]|join(".") -%}
+  {% set win_suffix = version[-1:] -%}
+  {% if win_suffix|int > 1 -%}
+  {%   set compact_version = git_version ~ "." ~ win_suffix -%}
+  {% else -%}
+  {%   set compact_version = git_version -%}
+  {% endif -%}
+  {% if version in new_style_versions -%}
+  {%   set display_version = version -%}
+  {% else -%}
+  {%   set display_version = compact_version -%}
+  {% endif -%}
   '{{ display_version }}':
-    {% if salt["pkg.compare_versions"](version, "<", "2.33.0") -%}
-    {%   set displayname_version = " version " ~ display_version -%}
+    {% if salt["pkg.compare_versions"](version, "<", "2.33.0.windows.1") -%}
+    {%   set full_name_suffix = " version " ~ display_version -%}
     {% endif -%}
-    full_name: Git{{ displayname_version | default("") }}
-    {%- if version not in uninstall_only %}
-    installer: https://github.com/git-for-windows/git/releases/download/v{{ extended_version }}/Git-{{ version }}-{{ arch }}-bit.exe
+    full_name: Git{{ full_name_suffix|d }}
+    {% if version not in uninstall_only -%}
+    installer: https://github.com/git-for-windows/git/releases/download/v{{ version }}/Git-{{ compact_version }}-{{ arch }}-bit.exe
     # It is impossible to downgrade git silently. It will always pop a message
     # that will cause salt to hang. `/SUPPRESSMSGBOXES` will suppress that
     # warning allowing salt to continue, but the package will not downgrade
     install_flags: /VERYSILENT /NORESTART /SP- /NOCANCEL /SUPPRESSMSGBOXES
-    {%- endif %}
+    {% endif -%}
     uninstaller: forfiles
-    uninstall_flags: '/p "%ProgramFiles%\Git" /m unins*.exe /c "cmd /c @path /VERYSILENT /NORESTART"'
-    msiexec: False
-    locale: en_US
-    reboot: False
-{% endfor %}
+    uninstall_flags: /p "%ProgramFiles%\Git" /m unins*.exe /c "cmd /c @path /VERYSILENT /NORESTART"
+{%- endfor %}
 
 {% set PROGRAM_FILES = {'AMD64': '%ProgramFiles(x86)%', 'x86': '%ProgramFiles%'}[salt["grains.get"]("cpuarch")] -%}
 
@@ -185,24 +182,15 @@ msysgit:
     install_flags: '/VERYSILENT /NORESTART /SP- /NOCANCEL'
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART '
-    msiexec: False
-    locale: en_US
-    reboot: False
   '1.9.5-preview20141217':
     full_name: 'Git version 1.9.5-preview20141217'
     installer: 'https://github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20141217/Git-1.9.5-preview20141217.exe'
     install_flags: '/VERYSILENT /NORESTART /SP- /NOCANCEL'
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NORESTART'
-    msiexec: False
-    locale: en_US
-    reboot: False
   '1.9.4-preview20140815':
     full_name: 'Git version 1.9.4-preview20140815'
     installer: 'https://github.com/msysgit/msysgit/releases/download/Git-1.9.4-preview20140815/Git-1.9.4-preview20140815.exe'
     install_flags: '/VERYSILENT /NOREBOOT'
     uninstaller: '{{ PROGRAM_FILES }}\Git\unins000.exe'
     uninstall_flags: '/VERYSILENT /NOREBOOT'
-    msiexec: False
-    locale: en_US
-    reboot: False

--- a/git.sls
+++ b/git.sls
@@ -13,6 +13,9 @@
 
 {% load_yaml as versions -%}
 # renovate: datasource=github-releases depName=git packageName=git-for-windows/git
+- 2.46.0.windows.1
+- 2.45.2.windows.1
+- 2.45.1.windows.1
 - 2.45.0.windows.1
 - 2.44.0.windows.1
 - 2.43.0.windows.1


### PR DESCRIPTION
- **refactor: make `git` versions match upstream release format**
- **ci: add Renovate comment to `git`**
- **update: add `git` versions up to v2.46.0.windows.1**
- **update: add `git` version v2.46.1.windows.1**
- **update: add `git` version v2.46.2.windows.1**
- **chore: update actions/checkout action to v4.2.0**
- **chore: update pre-commit hook python-jsonschema/check-jsonschema to v0.29.3**
- **update: add `firefox` version v131.0**
- **update: add `firefox-esr` version v128.3.0**
- **chore: update dependency actions/python-versions to v3.12.7**
- **chore: update pre-commit hook pre-commit/pre-commit-hooks to v5**
- **chore: update actions/checkout action to v4.2.1**
- **update: add `git` version v2.47.0.windows.1**
- **chore: update dependency actions/python-versions to v3.13.0**
- **chore(renovate): disable `custom.firefox` while waiting for upstream fix**
